### PR TITLE
Try to get a little more information into the error dialogue.

### DIFF
--- a/src/main/java/com/itextpdf/rups/model/ErrorDialogPane.java
+++ b/src/main/java/com/itextpdf/rups/model/ErrorDialogPane.java
@@ -49,6 +49,7 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Optional;
 
 /**
  * A utility to display a dialog showing Throwable object
@@ -71,7 +72,17 @@ public final class ErrorDialogPane {
     private static String getTraceString(Throwable th) {
         final StringWriter sw = new StringWriter();
         final PrintWriter pw = new PrintWriter(sw);
-        th.printStackTrace(pw);
+        Optional<Throwable> chuckIt = Optional.ofNullable(th);
+        chuckIt.map(Throwable::getLocalizedMessage)
+                .ifPresent(pw::println);
+        chuckIt.map(Throwable::getCause)
+                .map(Throwable::getLocalizedMessage)
+                .ifPresent(msg -> {
+                    pw.print("Caused by: ");
+                    pw.println(msg);
+                });
+        pw.append("[Stack Trace]\n");
+        chuckIt.ifPresent(throwable -> throwable.printStackTrace(pw));
         return sw.toString();
     }
 }

--- a/src/main/java/com/itextpdf/rups/model/ObjectLoader.java
+++ b/src/main/java/com/itextpdf/rups/model/ObjectLoader.java
@@ -42,6 +42,7 @@
  */
 package com.itextpdf.rups.model;
 
+import com.itextpdf.io.exceptions.IOException;
 import com.itextpdf.rups.view.Language;
 
 import javax.swing.SwingUtilities;
@@ -134,8 +135,13 @@ public class ObjectLoader extends SwingWorker<Void, Void> {
             progress.setMessage(Language.XREF_READING.getString());
             progress.setTotal(n);
         });
-        while (objects.storeNextObject()) {
-            SwingUtilities.invokeLater(() -> progress.setValue(objects.getCurrent()));
+        try {
+            while (objects.storeNextObject()) {
+                SwingUtilities.invokeLater(() -> progress.setValue(objects.getCurrent()));
+            }
+        }
+        catch (IOException ioe) {
+            progress.showErrorDialog(ioe);
         }
         SwingUtilities.invokeLater(() -> progress.setTotal(0));
         nodes = new TreeNodeFactory(objects);


### PR DESCRIPTION
 Update  getTraceString in ErrorDialogPane to show the error message and cause, if available. Catch exceptions that occur in doInBackground of ObjectLoader. This means at least some part of the pdf file gets loaded, although we've hit an error condition in a bad pdf file.